### PR TITLE
Make event/1,2,3 and track/2,3,4 overridable

### DIFF
--- a/lib/mixpanel.ex
+++ b/lib/mixpanel.ex
@@ -50,6 +50,9 @@ defmodule Mixpanel do
       defp get_process_name() do
         :"mixpanel_#{@otp_app}"
       end
+
+      defoverridable track: 1, track: 2, track: 3
+      defoverridable engage: 2, engage: 3, engage: 4
     end
   end
 end


### PR DESCRIPTION
To allow centralised customisation of the functions, e.g. for logging or feature flag checking