### PR TITLE
Make httpoison optional dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule Mixpanel.Mixfile do
 
   defp deps do
     [
-      {:httpoison, "~> 0.13"},
+      {:httpoison, "~> 0.13", optional: true},
       {:jason, "~> 1.0"},
       {:telemetry, "~> 1.0"},
       {:credo, "~> 0.2", only: :dev},


### PR DESCRIPTION
It's not like we would use it anyway at any rate. We're pinning it, so we might just as well as ignore id.